### PR TITLE
Module fallback usage only if module is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lastui/rocker",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "scripts": {
     "lint": "node ./cli/index.js lint",
     "build": "npm run build:dependencies && npm run build:platform && npm run build:bootstrap",

--- a/platform/src/component/Module.jsx
+++ b/platform/src/component/Module.jsx
@@ -52,7 +52,9 @@ const Module = forwardRef((props, ref) => {
     };
   }, [loadModule]);
 
-  if (!props.name) {
+  const availableModule = moduleLoader.isAvailable(props.name);
+
+  if (!props.name || !availableModule) {
     return null;
   }
 

--- a/platform/src/component/Module.jsx
+++ b/platform/src/component/Module.jsx
@@ -52,9 +52,9 @@ const Module = forwardRef((props, ref) => {
     };
   }, [loadModule]);
 
-  const availableModule = moduleLoader.isAvailable(props.name);
+  const available = moduleLoader.isAvailable(props.name);
 
-  if (!props.name || !availableModule) {
+  if (!props.name || !available) {
     return null;
   }
 

--- a/platform/src/kernel/registry/__tests__/loader.test.js
+++ b/platform/src/kernel/registry/__tests__/loader.test.js
@@ -283,5 +283,16 @@ describe("loader registry", () => {
         expect(spy).toHaveBeenCalledWith("module my-feature failed to load", "ouch");
       });
     });
+
+    describe(".isAvailable", () => {
+      beforeEach(async () => {
+        await moduleLoader.setAvailableModules([]);
+      });
+
+      it("checks is module is available", async () => {
+        const available = moduleLoader.isAvailable("my-feature");
+        expect(available).toEqual(true);
+      });
+    });
   });
 });

--- a/platform/src/kernel/registry/loader.js
+++ b/platform/src/kernel/registry/loader.js
@@ -148,8 +148,11 @@ const createModuleLoader = () => {
     await Promise.allSettled(scheduledUnload);
   };
 
+  const isAvailable = (id) => Boolean(availableModules);
+
   return {
     setAvailableModules,
+    isAvailable,
     loadModule,
     getLoadedModule,
   };


### PR DESCRIPTION
`fallback` property when consuming Module will be invoked only if module is not ready and and is available.